### PR TITLE
Remove the downloadable complaint form

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,9 +613,7 @@ The Quality Commissioner aims to resolve disputes individual students may have w
 
 ## Complaint Form.
 
-Where a student wishes to make an informal complaint about something affecting their study on any programme at Developers Institute, a digital submission can be made [here.](https://share.hsforms.com/1g9naEKN4TJubxTsUkA2YoA4fxim)
-
-Alternatively a form can be [downloaded.](https://github.com/Developers-Institute/Student-Concerns-Complaints-Academic-Appeals-and-Disciplinary-Policy/raw/master/Complaint%20Form.pdf)
+Where a student wishes to make an informal complaint about something affecting their study on any programme at Developers Institute, a submission can be made [here.](https://share.hsforms.com/1g9naEKN4TJubxTsUkA2YoA4fxim)
 
 ## Student Guidance and Support.
 


### PR DESCRIPTION
## Proposed Changes
- Remove the downloadable complaint form as it contains the wrong link to `typeform`.
- This issue is related to [QM-127](https://developersinstitute.atlassian.net/browse/QM-127?focusedCommentId=18926&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18926).